### PR TITLE
Call SetChunkSize instead of SetBufferSize where appropriate

### DIFF
--- a/src/splitter.cc
+++ b/src/splitter.cc
@@ -206,7 +206,7 @@ int main(int argc, const char *argv[]) {
   }
 
   if (vm.count("chunk_size")) {
-    splitter_ptr->SetBufferSize(vm["chunk_size"].as<int>());
+    splitter_ptr->SetChunkSize(vm["chunk_size"].as<int>());
   }
 
   if (vm.count("header_size")) {


### PR DESCRIPTION
Fixes a typo causing a segmentation fault in SplitterLRS.
